### PR TITLE
Fix: Use case-insensitive comparison for username in Login

### DIFF
--- a/ComicRentalSystem_14Days/Services/AuthenticationService.cs
+++ b/ComicRentalSystem_14Days/Services/AuthenticationService.cs
@@ -98,7 +98,7 @@ namespace ComicRentalSystem_14Days.Services
         public User? Login(string username, string password)
         {
             _logger.Log($"Login attempt for username: {username}");
-            User? user = _context.Users.FirstOrDefault(u => u.Username.Equals(username, StringComparison.OrdinalIgnoreCase));
+            User? user = _context.Users.FirstOrDefault(u => u.Username.ToLower() == username.ToLower());
 
             if (user == null)
             {


### PR DESCRIPTION
The LINQ query in the `Login` method was changed to use `ToLower()` for username comparison. This resolves an `InvalidOperationException` caused by the use of `string.Equals` with `StringComparison.OrdinalIgnoreCase`, which is not supported by Entity Framework Core.